### PR TITLE
adding -H flag to pass the 'name' parameter...

### DIFF
--- a/lib/chef/knife/cloudstack_server_create.rb
+++ b/lib/chef/knife/cloudstack_server_create.rb
@@ -109,6 +109,11 @@ class Chef
               :long => "--server-name NAME",
               :description => "The server name"
       
+      option  :host_name,
+              :short => "-H NAME",
+              :long => "--hostname NAME",
+              :description => "The hostname"
+      
       option  :keypair,
               :short => "-k KEYPAIR",
               :long => "--keypair KEYPAIR",
@@ -180,6 +185,10 @@ class Chef
         
         if locate_config_value(:server_name) != nil
           options['displayname'] = locate_config_value(:server_name)
+        end
+
+        if locate_config_value(:host_name) != nil
+          options['name'] = locate_config_value(:host_name)
         end
         
         security_groups = []


### PR DESCRIPTION
...which ends up being the hostname for the virtual machine as well as the only name for the cloudstack VM in the webui.  The benefits are as follows:

1) This makes the name of the node consistent between the Chef server and Cloudstack
2) This therefore allows you to delete by the same name, from Cloudstack and the Chef server
3) The name also becomes the hostname of the node
    a) So when you login, you no longer see the abstract hostnames like "i-3-180-VM" but a descriptive hostname on your bash prompt.  
