### PR TITLE
Added a conditional for displaying 'hypervisor' in 'knife cloudstack template list'

### DIFF
--- a/lib/chef/knife/cloudstack_template_list.rb
+++ b/lib/chef/knife/cloudstack_template_list.rb
@@ -73,6 +73,7 @@ class Chef
         
         temp.each do |template|
           template_list << template['id'].to_s
+          template['hypervisor'] = ' ' if template['hypervisor'].nil?
           template_list << template['hypervisor']
 
           template_size = template['size']


### PR DESCRIPTION
...since the 3.0 CS API we are using and have no control over, is not currently passing the hypervisor of the VM and therefore breaks the listing of the available templates.
