### PR TITLE
SSH key authentication feature of "server create" subcommand

### DIFF
--- a/knife-cloudstack-fog.gemspec
+++ b/knife-cloudstack-fog.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb']
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog", "~> 1.3.1"
+  s.add_dependency "fog", "~> 1.4.0"
 end

--- a/lib/chef/knife/cloudstack_server_create.rb
+++ b/lib/chef/knife/cloudstack_server_create.rb
@@ -99,6 +99,11 @@ class Chef
               :long => "--ssh-password PASSWORD",
               :description => "The ssh password"
               
+      option  :identity_file,
+              :short => "-i PRIVATE_KEY_FILE",
+              :long => "--identity-file PRIVATE_KEY_FILE",
+              :description => "The Private key file for authenticating SSH session. --keypair option is also needed."
+            
       option  :server_name,
               :short => "-N NAME",
               :long => "--server-name NAME",
@@ -227,7 +232,7 @@ class Chef
         print "#{ui.color("Waiting for server", :magenta)}"
         while server_start['queryasyncjobresultresponse'].fetch('jobstatus') != 1
           print "#{ui.color(".", :magenta)}"
-          sleep(1)
+          sleep(15)
           server_start = connection.query_async_job_result('jobid'=>jobid)
         end
         puts "\n\n"


### PR DESCRIPTION
Hi,

Thank you for merging my code to cloudstack_server_create.rb .

I have added a feature to cloudstack_server_create.rb which enable SSH key authentication when Chef workstation login to Chef client. (I create this branch because the templates on our company's public cloud "IDC Frontier Cloud service" doesn't support SSH password authentication by default.)

Would you please check this request and merge this branch?

And, if you don't mind, would you please add the following copyright notation to cloudstack_server_create.rb ?

```
  Copyright (c) 2012 IDC Frontier Inc.
```

Best Regards,

Takashi Kanai
anikundesu@gmail.com
