### PR TITLE
Server start/stop run in batches

### DIFF
--- a/lib/chef/knife/cloudstack_server_start.rb
+++ b/lib/chef/knife/cloudstack_server_start.rb
@@ -32,40 +32,43 @@ class Chef
         end
 
         jobs = {}
+        batch_size = 5
 
-        @name_args.each do |instance_id|
-          response = connection.list_virtual_machines('name' => instance_id)
-          instance_name = response['listvirtualmachinesresponse']['virtualmachine'].first['name']
-          instance_ip = response['listvirtualmachinesresponse']['virtualmachine'].first['nic'].first['ipaddress']
-          real_instance_id = response['listvirtualmachinesresponse']['virtualmachine'].first['id']
-          puts "#{ui.color("Name", :green)}: #{instance_name}"
-          puts "#{ui.color("Public IP", :green)}: #{instance_ip}"
-          puts "\n"
-          confirm("#{ui.color("Do you really want to start this server", :green)}")
+        @name_args.each_slice(batch_size) do |batch|
+          batch.each do |instance_id|
+            response = connection.list_virtual_machines('name' => instance_id)
+            instance_name = response['listvirtualmachinesresponse']['virtualmachine'].first['name']
+            instance_ip = response['listvirtualmachinesresponse']['virtualmachine'].first['nic'].first['ipaddress']
+            real_instance_id = response['listvirtualmachinesresponse']['virtualmachine'].first['id']
+            puts "#{ui.color("Name", :green)}: #{instance_name}"
+            puts "#{ui.color("Public IP", :green)}: #{instance_ip}"
+            puts "\n"
+            confirm("#{ui.color("Do you really want to start this server", :green)}")
 
 
-          if locate_config_value(:force)
-            server = connection.start_virtual_machine('id' => real_instance_id, 'forced' => true)
-          else
-            server = connection.start_virtual_machine('id' => real_instance_id)
-          end
-          jobid = server['startvirtualmachineresponse'].fetch('jobid')
-
-          jobs[instance_id] = jobid
-        end
-
-        print "#{ui.color("Waiting for servers", :magenta)}"
-        until jobs.empty?
-          jobs.each do |instance_id, jobid|
-            server_start = connection.query_async_job_result('jobid'=>jobid)
-            if server_start['queryasyncjobresultresponse'].fetch('jobstatus') == 1
-              jobs.delete(instance_id)
-
-              puts "\n\n"
-              ui.warn("Started server #{instance_id}")
+            if locate_config_value(:force)
+              server = connection.start_virtual_machine('id' => real_instance_id, 'forced' => true)
             else
-              print "#{ui.color(".", :magenta)}"
-              sleep(1)
+              server = connection.start_virtual_machine('id' => real_instance_id)
+            end
+            jobid = server['startvirtualmachineresponse'].fetch('jobid')
+
+            jobs[instance_id] = jobid
+          end
+
+          print "#{ui.color("Waiting for servers", :magenta)}"
+          until jobs.empty?
+            jobs.each do |instance_id, jobid|
+              server_start = connection.query_async_job_result('jobid'=>jobid)
+              if server_start['queryasyncjobresultresponse'].fetch('jobstatus') == 1
+                jobs.delete(instance_id)
+
+                puts "\n\n"
+                ui.warn("Started server #{instance_id}")
+              else
+                print "#{ui.color(".", :magenta)}"
+                sleep(1)
+              end
             end
           end
         end


### PR DESCRIPTION
It seems that virtual router can handle only limited amount of new VMs at the same time, 
so I've limited number of parallel requests so such problems should not emerge.

Quote from API support ticket.

```
So it is possible that the virtual router cannot handle such many VMs (25+) launching at the same time.
Therefore we suggested user to launch VM by no more than 5 at a time.
```
