### PR TITLE
Support user data for cloudstack

### DIFF
--- a/lib/chef/knife/cloudstack_server_create.rb
+++ b/lib/chef/knife/cloudstack_server_create.rb
@@ -270,8 +270,9 @@ class Chef
         end
 
         if locate_config_value(:cloudstack_user_data) != nil
+          require 'base64'
           begin
-            server_def["userdata"] = [File.read(Chef::Config[:knife][:cloudstack_user_data])].pack('m')
+            server_def["userdata"] = Base64.strict_encode64(File.read(Chef::Config[:knife][:cloudstack_user_data]))
           rescue
             ui.warn("Cannot read #{Chef::Config[:knife][:cloudstack_user_data]}: #{$!.inspect}. Ignoring")
           end


### PR DESCRIPTION
tested against cloudstack 2.2.15 only but should work with 4.x, too.

the file must be base64-encoded because fog does not encode it for you. will create a patch soon.
