### PR TITLE
correct "create server" command banner error

### DIFF
--- a/lib/chef/knife/cloudstack_server_create.rb
+++ b/lib/chef/knife/cloudstack_server_create.rb
@@ -31,7 +31,7 @@ class Chef
 
       include Knife::CloudstackBase
 
-      banner "knife cloudstack server create -s SERVICEID -t TEMPLATEID -z ZONEID (options)"
+      banner "knife cloudstack server create -s SERVICEID -t TEMPLATEID -Z ZONEID (options)"
 
       option  :cloudstack_serviceid,
             :short => "-s SERVICEID",


### PR DESCRIPTION
banner requests '-z' option, but it should be '-Z'.
